### PR TITLE
Fix package search to handle @types packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ var analysis = require('./lib/analysis');
 var remote = require('./lib/remote');
 var opt = require('minimist')(process.argv.filter(e => !/\/.+$/.test(e)));
 
+var isWin = /^win/.test(process.platform);
+
 opt.show = opt.show || [];
 opt.show = opt.show instanceof Array ? opt.show : [opt.show];
 
@@ -28,6 +30,11 @@ opt.type = opt.type instanceof Array ? opt.type : [opt.type];
 opt.width = opt.width || 80;
 opt.width = typeof opt.width === 'number' ? opt.width : 80;
 
+// node on windows inserts extra into argv that we need to remove
+// could be a bug in minimist
+if (isWin) {
+  opt._ = opt._.slice(2);
+}
 
 var licenses;
 if (opt._.length) {

--- a/lib/folders.js
+++ b/lib/folders.js
@@ -8,7 +8,16 @@ module.exports = function walk(root){
   if (!fs.existsSync(mod)) return [];
 
   // Read all of the current modules and load the correct ones
-  var list = fs.readdirSync(mod).filter(e => !/^\./.test(e)).map(e => mod + e);
+  var list = fs.readdirSync(mod)
+    .filter(e => !/^@types/.test(e))  // skip @types directory for now
+    .filter(e => !/^\./.test(e)).map(e => mod + e);
+
+  // now add any @types modules
+  var typesDir = mod + '@types/';
+  if (fs.existsSync(typesDir)) {
+    var typesList = fs.readdirSync(typesDir).filter(e => !/^\./.test(e)).map(e => typesDir + e);
+    list.push.apply(list, typesList)
+  }
 
   // Add all of the children in a flattened array
   list = list.reduce((all, e) => all.concat(walk(e)), list);

--- a/lib/legally.js
+++ b/lib/legally.js
@@ -5,7 +5,12 @@ var open = require('./open');
 var folders = require('./folders');
 
 function getPackage(path){
-  var name = path.split(/\//).pop();
+  var name;
+  if (path.indexOf("@types") > 0) {
+    name = path.split(/\//).slice(-2).join('/');
+  } else {
+    name = path.split(/\//).pop();
+  }
   var pkg = require(path + '/package.json');
   return name + '@' + pkg.version;
 }


### PR DESCRIPTION
Typescript now installs type declarations in subdirectories under
node_modules/@types. This adds code to correctly include these
packages when building the list as well as when printing the
packages titles in the report.

Also adds a small change to work on Node on Windows. The way node
recursively call node.cli results in a couple of extra arguments in
opt._ that we need to remove. This may be a bug in minimist but
seems pretty easy to work around.