### PR TITLE
Add support for output plain text

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ legally --border ascii  # This will work in most systems
 
 ![ASCII style](images/borders.png)
 
+You can use the `--plain` option for output without any [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code):
+
+```bash
+legally --plain
+legally --plain > license-report.txt
+```
+
 Lastly, you can also add a width if not all of your licenses are displayed correctly and will adjust it *approximately*. Make sure to adjust your terminal size accordingly. It defaults to `80`:
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ if (opt.show.length === 0) {
 
 opt.filter = opt.filter || [];
 opt.type = opt.type || [];
+opt.plain = Boolean(opt.plain);
 
 opt.filter = opt.filter instanceof Array ? opt.filter : [opt.filter];
 opt.type = opt.type instanceof Array ? opt.type : [opt.type];

--- a/lib/table.js
+++ b/lib/table.js
@@ -28,13 +28,14 @@ function fixed (text, width, ch = ' '){
 // |---------------------------|----------------|----------------|----------------|
 // |                                 Title                                        |
 // |---------------------------|----------------|----------------|----------------|
-function title(title, widths){
+function title(title, widths, opt){
   var wid = title.length;
   var total = widths.reduce((a, b) => a + b + 3, 0) - 1;
   var left = parseInt((total - wid) / 2);
+  if (!opt.plain) title = '\u001b[1m' + title + '\u001b[22m';
   log(p[0][0] + widths.map(col => p.h + strN(col, p.h) + p.h).join(p.h) + p[0][2]);
   log(p.v + widths.map(col => ' ' + strN(col, ' ') + ' ').join(' ') + p.v);
-  log(p.v + strN(left) + '\u001b[1m' + title + '\u001b[22m' + strN(total - left - wid) + p.v);
+  log(p.v + strN(left) + title + strN(total - left - wid) + p.v);
   log(p.v + widths.map(col => ' ' + strN(col, ' ') + ' ').join(' ') + p.v);
 }
 
@@ -68,7 +69,7 @@ module.exports = function(data = [], columns = { '-': 76 }, opt = {}){
   log('\n');
 
   if (opt.title) {
-    title(opt.title, widths);
+    title(opt.title, widths, opt);
   }
 
   header(columns, opt, false, columns instanceof Array);


### PR DESCRIPTION
Add an option `--plain` to support for output without any [ANSI escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code).

Now we can use `legally --plain > license-report.txt` to get an awesome file.
