### PR TITLE
Remove console.log

### DIFF
--- a/src/remote.js
+++ b/src/remote.js
@@ -13,7 +13,6 @@ const sanitize = name => name
 
 module.exports = async packages => {
   if (!packages || !packages.length) return './node_modules';
-  console.log("Working on it. It will take a while...");
 
   if (!(await exists(join(tmpdir(), 'legally')))) {
     await mkdir(join(tmpdir(), 'legally'))


### PR DESCRIPTION
It seems unnecessary, and pollutes the output of any script using the API.