### PR TITLE
make it work on Node13

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "3.5.0",
   "description": "Check the licenses for the packages that you are using",
   "main": "cli.js",
-  "type": "module",
   "engines": {
     "node": ">=6.0.0"
   },


### PR DESCRIPTION
This fixes

````
>nvm use 13
Now using node v13.5.0 (npm v6.13.4)
>npx legally -l -r
(node:72888) ExperimentalWarning: The ESM module loader is experimental.
file:///Users/jand/Scratchpad/toryt/flowlogger/node_modules/legally/cli.js:2
require("./index.min.js");
^

ReferenceError: require is not defined
    at file:///Users/jand/Scratchpad/toryt/flowlogger/node_modules/legally/cli.js:2:1
    at ModuleJob.run (internal/modules/esm/module_job.js:110:37)
    at async Loader.import (internal/modules/esm/loader.js:141:24)
````

We got a warning for this on Node 12:

````
(node:189) Warning: require() of ES modules is not supported.
require() of /opt/atlassian/pipelines/agent/build/node_modules/legally/cli.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename cli.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /opt/atlassian/pipelines/agent/build/node_modules/legally/package.json.
````

There seems to be no good reason why `"type": "module"` was added in `14d7e4976b1b6dd22755a2ae84781b30a5c3732b` on 2019-11-30.