### PR TITLE
allow fetching of specific versions

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,10 @@
 const validate = require("validate-npm-package-name");
 const invalid = name => !validate(name).validForNewPackages;
+const nameWithoutVersion = entry => {
+  const index = entry.indexOf("@");
+  if (index === -1) { return entry };
+  return entry.substring(0, index);
+}
 
 module.exports = (opt = {}) => {
   // Clone the object to avoid modifying the reference
@@ -10,7 +15,7 @@ module.exports = (opt = {}) => {
   if (Array.isArray(opt)) opt = { routes: opt };
   opt.routes = opt.routes || [];
 
-  const bad = opt.routes.find(invalid);
+  const bad = opt.routes.map(nameWithoutVersion).find(invalid);
   if (bad) {
     throw new Error(`Invalid package name: "${bad}"`);
   }

--- a/src/options.js
+++ b/src/options.js
@@ -1,8 +1,8 @@
 const validate = require("validate-npm-package-name");
 const invalid = name => !validate(name).validForNewPackages;
 const nameWithoutVersion = entry => {
-  const index = entry.indexOf("@");
-  if (index === -1) { return entry };
+  const index = entry.lastIndexOf("@");
+  if (index < 1) { return entry };
   return entry.substring(0, index);
 }
 

--- a/src/remote.js
+++ b/src/remote.js
@@ -28,7 +28,7 @@ module.exports = async packages => {
   }
 
   // Create an empty namespaced temporary folder
-  const tmp = await join(tmpdir(), "legally", "pack-" + packages.join("-").replace("@", "_"));
+  const tmp = await join(tmpdir(), "legally", "pack-" + packages.join("-").replace(/@|\//g, "_"));
 
   // It is already cached, so we don't need to worry about it
   if ((await exists(tmp)) && new Date() - (await stat(tmp).atime) < CACHE) {

--- a/src/remote.js
+++ b/src/remote.js
@@ -28,7 +28,13 @@ module.exports = async packages => {
   }
 
   // Create an empty namespaced temporary folder
-  const tmp = await join(tmpdir(), "legally", "pack-" + packages.join("-").replace(/@|\//g, "_"));
+  const tmp = await join(tmpdir(), "legally", "pack-" + packages.map(entry => {
+    // @scope/name@0.1.0 -> @scope/name_0.1.0
+    // as npm does not allow package-names like <name>@<version>
+    const index = entry.lastIndexOf("@");
+    if (index < 1) { return entry; }
+    return entry.substring(0, index) + '_' + entry.substring(index + 1);
+  }).join("-"));
 
   // It is already cached, so we don't need to worry about it
   if ((await exists(tmp)) && new Date() - (await stat(tmp).atime) < CACHE) {

--- a/src/remote.js
+++ b/src/remote.js
@@ -28,7 +28,7 @@ module.exports = async packages => {
   }
 
   // Create an empty namespaced temporary folder
-  const tmp = await join(tmpdir(), "legally", "pack-" + packages.join("-"));
+  const tmp = await join(tmpdir(), "legally", "pack-" + packages.join("-").replace("@", "_"));
 
   // It is already cached, so we don't need to worry about it
   if ((await exists(tmp)) && new Date() - (await stat(tmp).atime) < CACHE) {
@@ -42,7 +42,7 @@ module.exports = async packages => {
   const packs = packages.map(sanitize).join(" ");
   // Need to be in a single place to keep the folder context
   await exec(
-    `cd "${tmp}" && npm init --yes && npm install ${packs} --ignore-scripts`
+    `cd "${tmp}" && npm init --yes && npm install ${packs} --ignore-scripts --save-exact`
   );
   return await join(tmp, "node_modules");
 };


### PR DESCRIPTION
This allows to fetch a specific version of a package like `node cli.js <package>@<version>`.

Usecase: Legacy projects with not up2date dependencies, where licenses might be changed in the meanwhile.