### PR TITLE
Fixed 'Error: Invalid package name: "process"'

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -1,5 +1,5 @@
 const validate = require("validate-npm-package-name");
-const invalid = name => !validate(name).validForNewPackages;
+const invalid = name => !validate(name).validForOldPackages;
 const nameWithoutVersion = entry => {
   const index = entry.lastIndexOf("@");
   if (index < 1) { return entry };


### PR DESCRIPTION
There are some old modules, which have wild names. With this change, the exception will not throw for old modules.