### PR TITLE
fix node-api for esm

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,2 +1,3 @@
 #!/usr/bin/env node
-require("./index.min.js");
+const legally = require("./index.min.js");
+legally.RunNow();

--- a/src/index.js
+++ b/src/index.js
@@ -43,10 +43,19 @@ async function RunNow()
   }
 }
 
-module.exports = legally;
+module.exports = async (args) => {
+  // imported as node-node module and not running via CLI
+  const options = clean(args);
+  const folder = await remote(options.routes);
+  const licenses = await legally(folder);
+  return licenses;
+};
+
 (async () =>
 {
-  if (require.main.id === '.')
+  // require.main is not defined when using import instead of require
+  // checking main.id, as rollup will not provide module
+  if (require.main && require.main.id === '.')
   {
     // CLI mode
     await RunNow();

--- a/src/index.js
+++ b/src/index.js
@@ -43,21 +43,12 @@ async function RunNow()
   }
 }
 
-module.exports = async (args) => {
+const api = async (args) => {
   // imported as node-node module and not running via CLI
   const options = clean(args);
   const folder = await remote(options.routes);
   const licenses = await legally(folder);
   return licenses;
 };
-
-(async () =>
-{
-  // require.main is not defined when using import instead of require
-  // checking main.id, as rollup will not provide module
-  if (require.main && require.main.id === '.')
-  {
-    // CLI mode
-    await RunNow();
-  }
-})();
+api.RunNow = RunNow; // CLI
+module.exports = api;


### PR DESCRIPTION
Fixes the usage of legally in ES Modules.

Previously failed with `TypeError: Cannot read property 'id' of undefined`. After fixing the crash, I noticed, that it returned an empty object. This is fixed as well.

Tested via:
```sh
mkdir legally-test
cd legally-test
npm init -y
npm install https://github.com/tasketo/legally#c7f6de7e055de2c7fd3e7b610459abb65c4ce86a
touch test.mjs
node test.mjs
```

test.mjs like in the README, but with `import` instead of `require`:
```javascript
import legally from 'legally'

var done = (function wait () { if (!done) setTimeout(wait, 1000) })();

(async () => {
  const licenses = await legally('express');
  console.log(licenses);
  // {
  //   'accepts@1.3.5': { package: [ 'MIT' ], license: [ 'MIT' ], readme: [] },
  //   'array-flatten@1.1.1': { package: [ 'MIT' ], license: [ 'MIT' ], readme: [] },
  //   ...
  // }
  done = true;
})();
```

Note: The node api of legally is still broken, when using `require`. It executes the `RunNow`. I am not sure how to fix that, as rollup prevents checks via `module`, which should do the job as documented [here](https://nodejs.org/docs/latest/api/modules.html#modules_accessing_the_main_module). At least for me using node v15.3.0.